### PR TITLE
Add a warning about committing to main.

### DIFF
--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -20,6 +20,19 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+::: caution
+
+### Committing to Main
+
+In this lesson you will be making changes on `main`.
+The `main` branch normally contains stable production code and
+should **NEVER** be committed to directly.
+In a later episode you will learn a basic workflow to
+ensure you never commit to main;
+and learn what to do when you accidentally commit to main.
+
+:::
+
 First let's make sure we're still in the right directory.
 You should be in the `recipes` directory.
 


### PR DESCRIPTION
Adds in a caution callout before the start of 04 tracking changes. This will need updating with a relative link to the branches episode or advanced lesson when they are ready.