### PR TITLE
Add in git and GitHub to the glossary

### DIFF
--- a/episodes/01-basics.md
+++ b/episodes/01-basics.md
@@ -62,6 +62,24 @@ metadata make up a [repository](../learners/reference.md#repository).
 Repositories can be kept in sync across different computers, facilitating
 collaboration among different people.
 
+## Terminology
+
+This workshop may contain language that is new to you.
+The [Glossary](../learners/reference.md#glossary) section
+outlines key Git & GitHub terminology for your reference.
+
+::: instructor
+
+### Explain Key Terminology
+
+Take this opportunity to show the learners where the glossary can be found.
+Explain the difference between Git & GitHub using the glossary!
+Or if there is time to spare, the first challenge on this page
+gets the learners to use the glossary to explain the difference
+to a partner or write it down in their own words.
+
+:::
+
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## The Long History of Version Control Systems
@@ -98,6 +116,16 @@ fcm ...
 ```
 
 :::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::  challenge
+
+Use the [Glossary](../learners/reference.md#glossary) to describe
+the difference between Git & GitHub in your own words.
+
+Share your description with other learners if you
+are comfortable doing so.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -17,6 +17,11 @@ title: 'Git Cheatsheets for Quick Reference'
 :   A git branch is a pointer to a commit. Branches are used to develop
 changes in parallel, isolated from each other.
 
+[centralised version control]{#cvc}
+:   In a centralised version control system such as Subversion
+a single server contains the main copy of a repository.
+Working on code requires internet access to the repository.
+
 [changeset]{#changeset}
 :   A group of changes to one or more files that are or will be added
 to a single [commit](#commit) in a [version control](#version-control)
@@ -34,6 +39,26 @@ all of the changes are recorded together.
 that is incompatible with changes made by other users.
 Helping users [resolve](#resolve) conflicts
 is one of version control's major tasks.
+
+[distributed version control]{#dvc}
+:   In a distributed version control system such as [Git](#git)
+each collaborator has an entire copy of the whole repository
+and its history.
+Working on code does not require internet access and there
+are multiple backups of the entire repository.
+
+[git]{#git}
+:   [Git](https://git-scm.com/) is a free and open source
+Version Control System (VCS) capable of tracking the history
+of our files and recover previous versions.
+Git is an example of a [distributed version control](#dvc) as
+opposed to a [centralised version control](#cvc) system such as Subversion.
+
+[GitHub]{#github}
+:   [GitHub](https://docs.github.com/en/get-started/start-your-journey/about-github-and-git)
+is a cloud-based platform where you can store, share,
+and work together with others to write code.
+It uses [git](#git) to version control files.
 
 [HTTP]{#http}
 :   The Hypertext Transfer [Protocol](#protocol) used for sharing web pages and other data


### PR DESCRIPTION
Fixes #72 
Add in an instructor note in episode 1 to ensure the glossary and difference between Git and GitHub are mentioned.