### PR TITLE
Update 09-branches.md

### DIFF
--- a/episodes/09-branches.md
+++ b/episodes/09-branches.md
@@ -61,8 +61,6 @@ $ git status
 
 ```output
 On branch main
-Your branch is up to date with 'origin/main'.
-
 nothing to commit, working tree clean
 ```
 


### PR DESCRIPTION
Closes #110 
Removes invalid up to date with origin/main line in the output of the first git status.