### PR TITLE
Update setup.md with prompt.bash change warning

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -196,6 +196,8 @@ fi
 unset rc
 ```
 
+These lines should only be added to the `~/.bashrc` file. Do not add them to your `prompt.bash` file.
+
 ::: caution
 
 ### GIT_PROMPT_PATH


### PR DESCRIPTION
Explicitly tell users not to add sourcing of .d files to the added .d file.

This is intended as a catch all as a couple of examples of people adding the sourcing lines to their prompt.bash have appeared in the wild after the course, which creates an infinite sourcing loop on login.